### PR TITLE
fixup! linux: device: close device property fd

### DIFF
--- a/lib/system/linux/device.c
+++ b/lib/system/linux/device.c
@@ -656,10 +656,13 @@ int metal_linux_get_device_property(struct metal_device *device,
 	fd = open(path, flags, mode);
 	if (fd < 0)
 		return -errno;
-	if (read(fd, output, len) < 0)
-		return -errno;
-	status = close(fd);
+	if (read(fd, output, len) < 0) {
+		status = -errno;
+		close(fd);
+		return status;
+	}
 
+	status = close(fd);
 	return status < 0 ? -errno : 0;
 }
 


### PR DESCRIPTION
Modify fd close logic so that the descriptor will always be closed, even if `read` returns an error. 